### PR TITLE
Refresh Italian localization 2/2

### DIFF
--- a/i18n/it/building.md
+++ b/i18n/it/building.md
@@ -1,8 +1,8 @@
 ## Step 0. (opzionale) Salta la compilazione e utilizza i file binari rilasciati
 
-Vedi il [README](https://github.com/monero-project/kovri/blob/master/README.md) per scaricare kovri pre-costruito e il file di checksum. Semplicemente installa e fai partire kovri. Pronti per partire!
+Vedi il [README](https://github.com/monero-project/kovri/blob/master/README.md) per scaricare kovri pre-compilato e il file di checksum. Semplicemente installa e avvia kovri. Pronti per partire!
 
-## Step 1. Se stai costruendo, requisiti minimi
+## Step 1. Se stai compilando, requisiti minimi
 
 ### Linux / MacOSX / FreeBSD 11 / OpenBSD 6
 - [Git](https://git-scm.com/download) 1.9.1
@@ -44,7 +44,7 @@ $ sudo apt-get install libminiupnpc-dev #Per utenti dietro un NAT restrittivo
 ```
 
 ### Ubuntu Trusty (14.04)
-Puoi costruire Boost dal codice sorgente oppure usando PPA
+Puoi compilare Boost dal codice sorgente oppure usando PPA
 Istruzioni per PPA:
 
 Dipendenze richieste:
@@ -63,7 +63,7 @@ $ sudo apt-get install libminiupnpc-dev #Per utenti dietro un NAT restrittivo
 ```
 
 ### Debian (stabile)
-Dovremo togliere da```testing``` per ```Boost 1.58+``` e a causa di [broken CMake](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826656). Per motivi di documentazione, toglieremo tutte le dipendenze da  ```testing```. Se non hai esperienza con apt-pinning, procedi con le seguenti istruzioni prima di installare le dipendenze:
+Dovremo togliere da```testing``` per ```Boost 1.58+```  a causa di [broken CMake](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826656). Per motivi di documentazione, toglieremo tutte le dipendenze da  ```testing```. Se non hai esperienza con apt-pinning, procedi con le seguenti istruzioni prima di installare le dipendenze:
 
 - Crea e modifica ```/etc/apt/preferences.d/custom.pref```
 - Salva il file con il seguente testo:
@@ -78,12 +78,12 @@ Pin: release a=testing
 Pin-Priority: 650
 ```
 - Crea e modifica ```/etc/apt/sources.list.d/custom.list```
-```
-# Stable
+
+# Stabile
 deb [Enter your mirror here] stable main non-free contrib
-# Testing
+# In test
 deb [Enter your mirror here] testing main non-free contrib
-```
+
 - Sostituisci ```[Enter your mirror here]``` con il tuo mirror (guarda ```/etc/apt/sources.list```)
 - Esegui ```$ sudo apt-get update```
 - Installa le dipendenze con ```-t testing```:
@@ -143,11 +143,12 @@ Dipendenze opzionali:
 ```bash
 $ sudo pkg_add miniupnpc #For users behind a restrictive NAT
 $ sudo pkg_add doxygen graphviz
+```
 
 # Compilazione ultimo boost
 ```bash
 # procurati ultimo boost
-$ wget [latest boost] -O latest_boost.tar.bz2
+$ wget [ultimo boost] -O latest_boost.tar.bz2
 $ tar xvjf latest_boost.tar.bz2 && cd latest_boost/
 
 # Scarica e applica le patch
@@ -155,13 +156,14 @@ $ tar xvjf latest_boost.tar.bz2 && cd latest_boost/
 # https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
 
 # Compilazione boost
+```
 $ echo 'using gcc : : eg++ : "-fvisibility=hidden -fPIC" "" "ar" "strip"  "ranlib" "" : ;' > user-config.jam
 $ config_opts="runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1"
 $ ./bootstrap.sh --without-icu --with-libraries=chrono,log,program_options,date_time,thread,system,filesystem,regex,test
 $ sudo ./b2 -d2 -d1 ${config_opts} --prefix=${BOOST_PREFIX} stage
 $ sudo ./b2 -d0 ${config_opts} --prefix=${BOOST_PREFIX} install
 ```
-**Note: see OpenBSD build instructions below**
+**Nota: vedi sotto istruzioni per compilare OpenBSD**
 
 
 ### Windows (MSYS2/MinGW-64)
@@ -175,10 +177,10 @@ pacman -Su
 ```
 * Chi di voi ha già familiarità con pacman può usare normalmente ```pacman -Syu``` per aggiornare, ma potresti ricevere degli errori e dover far ripartire MSYS2 se le dipendenze di pacman sono aggiornate.
 * Installa dipendenze: ```pacman -S make mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-boost mingw-w64-x86_64-openssl```
-* Opzionale: ```mingw-w64-x86_64-doxygen```  (avrai bisogno di[Graphviz](http://graphviz.org/doc/winbuild.html) per doxygen)
+* Opzionale: ```mingw-w64-x86_64-doxygen```  (avrai bisogno di [Graphviz](http://graphviz.org/doc/winbuild.html) per doxygen)
 * Nota: Avrai bisogno di  ``` mingw-w64-x86_64-miniupnpc``` se sei dietro un firewall NAT restrittivo.
 
-## Step 3. Build   
+## Step 3. Compilazione   
 
 ### 1. Clona la repository
 ```bash
@@ -209,14 +211,14 @@ $ make install
 - ```make doxygen``` produce documentazione Doxygen
 - ```make clean``` pulisce cartelle build e gli output Doxygen
 - ```make help``` mostra le opzioni di build CMake disponibili
-- ```make uninstall``` uninstall Kovri
+- ```make uninstall``` disinstalla Kovri
 
 #### Note
 - L'output di Doxygen sarà nella cartella```doc```
 - Tutti gli altri output di compilazione saranno nella cartella ```build```
 
 ### Clang
-Per eseguire il build con clang, **devi** esportare i seguenti:
+Per compilare con clang, **devi** esportare i seguenti:
 
 ```bash
 $ export CC=clang CXX=clang++  # rimpiazza ```clang``` con una versione/percorso di clang a tua scelta
@@ -234,10 +236,10 @@ $ gmake && gmake install
 $ export CC=clang CXX=clang++  # clang raccomandato, altrimenti egcc/eg++
 $ gmake && gmake install
 ```
-- Rimpiazza ```make``` with ```gmake``` per tutte le altre opzioni di compilazione
+- Rimpiazza ```make``` con ```gmake``` per tutte le altre opzioni di compilazione
 
 
-### (Opzionale) percorso data personalizzato
+### (Opzionale) percorso personalizzato
 Puoi personalizzare il percorso dei dati di Kovri a tuo piacimento. Semplicemente esporta ```KOVRI_DATA_PATH```; esempio:
 
 ```bash
@@ -273,7 +275,7 @@ procurati libFuzzer:
 $ git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer contrib/Fuzzer
 ```
 
-Costruisci kovri con fuzz testing abilitato:
+Compila kovri con fuzz testing abilitato:
 
 ```bash
 $ PATH="~/third_party/llvm-build/Release+Asserts/bin:$PATH" CC=clang CXX=clang++ make fuzz-tests

--- a/i18n/it/building.md
+++ b/i18n/it/building.md
@@ -156,7 +156,7 @@ $ tar xvjf latest_boost.tar.bz2 && cd latest_boost/
 # https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
 
 # Compilazione boost
-```
+
 $ echo 'using gcc : : eg++ : "-fvisibility=hidden -fPIC" "" "ar" "strip"  "ranlib" "" : ;' > user-config.jam
 $ config_opts="runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1"
 $ ./bootstrap.sh --without-icu --with-libraries=chrono,log,program_options,date_time,thread,system,filesystem,regex,test

--- a/i18n/it/faq.md
+++ b/i18n/it/faq.md
@@ -50,7 +50,7 @@ leggi il nostro [README](https://github.com/monero-project/kovri/blob/master/REA
 Abbiamo eseguito una fork per almeno questi motivi:
 
 - Volevamo una robusta, sicura e viabile implementazione C++ del network I2P; e i2pd non la forniva
-- Volevamo una community positiva in grado di incoraggiare collaborazione per il miglioramento del software; non negativa, narcisitica, in cerca gloria
+- Volevamo una community positiva in grado di incoraggiare collaborazione per il miglioramento del software; non negativa, narcisitica, in cerca di gloria
 - Volevamo un capo sviluppatore che sapesse comandare; non qualcuno che ignorasse richieste di divulgazione responsabile o che  rifiuti il confronto in caso di conflitti con i collaboratori
 
 ## Quali sono stati i motivi principali che hanno portato a "forkare" da i2ps (e perchè ci sono due repository: una su Bitbucket e l'altra su GitHub)?

--- a/i18n/it/faq.md
+++ b/i18n/it/faq.md
@@ -8,16 +8,16 @@ Leggi di più su Kovri nella [Moneropedia](https://getmonero.org/knowledge-base/
 ## Qual è lo stato attuale di Kovri?
 Kovri è attivamente sviluppato e correntemente nella fase pre-alpha. Kovri *non* è ancora integrato con Monero ma, oltre a varie features principali, stiamo sviluppando un [client](https://github.com/monero-project/kovri/issues/351) e un [core](https://github.com/monero-project/kovri/issues/350) API da usare per Monero e altre applicazioni.
 
-Correntemente, puoi usare il Kovri per connetterti (e partecipare) al network I2P: naviga eepsites, connettiti a IRC, apri un client e tunnel servers.
+Correntemente, puoi usare Kovri per connetterti (e partecipare) al network I2P: naviga eepsites, connettiti a IRC, apri un client e tunnel servers.
 
 ## Quando sarà la vostra prima release?
 Una release alpha è prevista per inizio 2017. Quando la qualità avrà raggiunto un livello sufficente alto e l'API sarà completamente implementata, Kovri diventerà un beta software.
 
 ## Perchè i miei log mostrano una data/ora diversa dalla mia timezone?
-I logs sono registrati in UTC per proteggere la tua privacy. Usando UTC, puoi caricare file di log da condividere con gli sviluppatori della community senza compromettere la tua anonimità.
+I logs sono registrati in UTC per proteggere la tua privacy. Usando UTC, puoi caricare file di log da condividere con gli sviluppatori della community senza compromettere il tuo anonimato.
 
 ## Su cosa si sta concentrando attualmente il team di sviluppatori?
-Correntemente, ci stiamo concentrando su tutto ciò che è listato nel nostro [issues tracker](https://github.com/monero-project/kovri/issues/). Coprono molto di quello che dobbiamo finire prima di una release ufficiale (alpha, beta o maggiore).
+Correntemente, ci stiamo concentrando su tutto ciò che è listato nel nostro [issues tracker](https://github.com/monero-project/kovri/issues/). Copre molto di quello che dobbiamo finire prima di una release ufficiale (alpha, beta o maggiore).
 
 ## Kovri è usabile, parzialmente usabile o non è raccomandato l'utilizzo per forte privacy al momento?
 Kovri può essere utilizzato secondo quanto il comando ```./kovri --help``` ha da offire. Kovri non ha attualmente alcuna interazione con Monero. Riguardo alla privacy, abbiamo sistemato molti problemi di sicurezza fin dall'inizio ma siamo ancora in pre-alpha.
@@ -32,16 +32,16 @@ leggi il nostro [README](https://github.com/monero-project/kovri/blob/master/REA
 ## Perchè dovrei usare Kovri invece di i2pd?
 - Sicurezza: il nostro obbiettivo è quello di rendere il nostro software sicuro; non di [fare le cose frettolosamente](https://github.com/monero-project/kovri/issues/65) solo per fare uscire una release
 - Qualità: stai supportando gli sforzi per assicurare un codebase di qualità che supererà il test del tempo. Questo include tutti gli aspetti della mantenibilità del codice
-- Monero: supporterai una cryptomoneta che fa della preservazione della privacy e dell'anonimità un vanto incrementandole entrambe
+- Monero: supporterai una cryptomoneta che fa della preservazione della privacy e dell'anonimità un vanto, incrementandole entrambe
 
 ## Quali sono le più grandi differenze tra Kovri e i2pd?
 
 - Abbiamo un [Forum Funding System](https://forum.getmonero.org/8/funding-required) per features/sviluppo.
-- Siamo concentrati nella creazione di un I2P router ["sicuro di default"](http://www.openbsd.org/security.html), facilmente mantenibile con più possibilità di reviews. Questo a costo di abbandonare le funzionalità meno utilizzate in altri routers, ma le funzionalità principali e le API rimarranno pienamente intatte. Creando un router più piccolo, efficente ed essenziale, forniremo a sviluppatori e ricercatori più tempo per audit di sicurezza e per mettere in discussione il design I2P e le sue specifiche.
-- Siamo concentrati nell'implementare un'intuitiva, developer-friendly API per qualsiasi applicazione per connettersi e usare il network I2P; Questo include Monero.
+- Siamo concentrati nella creazione di un router I2P ["sicuro di default"](http://www.openbsd.org/security.html), facilmente mantenibile con più possibilità di reviews. Questo a costo di abbandonare le funzionalità meno utilizzate in altri routers, ma le funzionalità principali e le API rimarranno pienamente intatte. Creando un router più piccolo, efficente ed essenziale, forniremo a sviluppatori e ricercatori più tempo per audit di sicurezza e per mettere in discussione il design I2P e le sue specifiche.
+- Siamo concentrati nell'implementare un'intuitiva, developer-friendly API per qualsiasi applicazione per connettersi e usare il network I2P, questo include Monero.
 - Forniamo sia agli utenti finali che agli sviluppatori una [garanzia di qualità](https://github.com/monero-project/kovri/issues/58) e un [modello di sviluppo](https://github.com/monero-project/kovri-docs/blob/master/i18n/it/contributing.md) in modo da fornire un software migliore a tutti/e.
-- implementeremo un opzione di reseeding alternativa così gli utenti potranno utilizzare [Pluggable Transports](https://www.torproject.org/docs/pluggable-transports.html.en) invece di HTTPS per il reseeding.
-- Implementeremo funzionalità estese *(modalità nascosta + inbound disabilitato)* per fornire anonimità per coloro che vivono in nazioni con condizioni estreme o per chi è sotto firewall da carrier-grade NAT o DS-Lite.
+- implementeremo un'opzione di reseeding alternativa così gli utenti potranno utilizzare [Pluggable Transports](https://www.torproject.org/docs/pluggable-transports.html.en) invece di HTTPS per il reseeding.
+- Implementeremo funzionalità estese *(modalità nascosta + inbound disabilitato)* per fornire anonimità a coloro che vivono in nazioni con condizioni estreme o per chi è sotto firewall da carrier-grade NAT o DS-Lite.
 - Creeremo sempre un ambiente di collaborazione amichevole.
 - Daremo sempre ascolto ai tuoi feedback e faremo del nostro meglio per migliorare Kovri!
 
@@ -50,8 +50,8 @@ leggi il nostro [README](https://github.com/monero-project/kovri/blob/master/REA
 Abbiamo eseguito una fork per almeno questi motivi:
 
 - Volevamo una robusta, sicura e viabile implementazione C++ del network I2P; e i2pd non la forniva
-- Volevamo una community positiva in grado di incoraggiare collaborazione per il miglioramento del software; non negativa, narcisitica gloria
-- Volevamo un capo sviluppatore che sapesse comandare; non qualcuno che ignorasse richieste di divulgazione responsabile o che  rifiutail confronto in caso di conflitti con i collaboratori
+- Volevamo una community positiva in grado di incoraggiare collaborazione per il miglioramento del software; non negativa, narcisitica, in cerca gloria
+- Volevamo un capo sviluppatore che sapesse comandare; non qualcuno che ignorasse richieste di divulgazione responsabile o che  rifiuti il confronto in caso di conflitti con i collaboratori
 
 ## Quali sono stati i motivi principali che hanno portato a "forkare" da i2ps (e perchè ci sono due repository: una su Bitbucket e l'altra su GitHub)?
 
@@ -63,7 +63,7 @@ Queste azioni hanno offeso molti nella community di I2P, inclusi gli sviluppator
 
 Nella primavera del 2015 arrivò anonimal, che non volendo vedere il lavoro di tutti venir sprecato, ha ravvivato il progetto tramite contributi propri. Venne mandato un invito a tutti gli sviluppatori attivi rimasti per riunirsi e discutere il futuro di i2pd. Il primo autore di i2pd non si è mai presentato, ma l'atto di riunirsi ha scrollato la ruggine dalle ali di i2pd abbastanza da farlo [ritrattare](https://github.com/PurpleI2P/i2pd/issues/279) e ricominciare a collaborare di nuovo su GitHub - ma questa volta con un ramo ```openssl``` (che si è poi rivelato essere la repository di Bitbucket) invece del ramo ```master``` guidato dalla community.
 
-Capendo che questo comportamento avrebe solo fatto male al network I2P e all'intero progetto, gli sviluppatori rimasti hanno continuato ad avere [vari meeting importanti](https://github.com/monero-project/kovri/issues/47) costruendo le fondamenta di quello che adesso è Kovri.
+Capendo che questo comportamento avrebe solo fatto male al network I2P e all'intero progetto, gli sviluppatori rimasti hanno continuato a riunirsi in [vari meeting importanti](https://github.com/monero-project/kovri/issues/47) costruendo le fondamenta di quello che adesso è Kovri.
 
 ## Ho trovato una vulnerabilità! Ho trovato un bug! Cosa devo fare?
 - Vulnerabilità: vedi il nostro [LEGGIMI](https://github.com/monero-project/kovri/blob/master/README.md)

--- a/i18n/it/style.md
+++ b/i18n/it/style.md
@@ -1,5 +1,5 @@
 # Stile
-1. Leggi la [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html)(in particolare riguardo allo stile non formattato)
+1. Leggi la [Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html) (in particolare riguardo allo stile non formattato)
    - Se stai programmando in bash, leggi la [Google's Shell Style Guide](https://github.com/google/styleguide/blob/gh-pages/shell.xml)
 2. Usa [clang-format](http://llvm.org/releases/3.8.0/tools/clang/docs/ClangFormat.html) con ```-style=file``` usando il [.clang-format](https://github.com/monero-project/kovri/blob/master/.clang-format) provvisto
 ```bash
@@ -16,14 +16,14 @@ $ cd kovri/ && cpplint src/path/to/my/file && [modifica il file manualmente per 
   - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#vim-integration)
   - [clang-format ubuntu 16.04 vim workaround](http://stackoverflow.com/questions/39490082/clang-format-not-working-under-gvim)
   - [cpplint.vim](https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/cpp/cpplint.vim)
-- Emacs integration
+- Integrazione Emacs
   - [clang-format](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration) + [clang-format.el](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el)
   - [flycheck-google-cpplint.el](https://github.com/flycheck/flycheck-google-cpplint)
 
 ## Qui c'è cos'è correntemente non catturato da clang-format e differisce dallo style C++ di Google
 
 - Evitare anteposti mixed-case ```k``` e MACRO_TYPE per tutte le costanti
-- Usa Doxygen three-slash ```/// C++ comments``` quando crei documentazione per Doxygen
+- Usa i tre slash di Doxygen ```/// C++ comments``` quando crei documentazione per Doxygen
 - Prova a documentare tutto il tuo lavoro per Doxygen mentre progredisci
 - Se l'anonimato è una preoccupazione, prova a fondere il tuo stile con quello di un contributore corrente
 

--- a/i18n/it/user_guide.md
+++ b/i18n/it/user_guide.md
@@ -3,11 +3,11 @@
 ## Step 1. Apri il tuo NAT/Firewall
 1.  Scegli una porta tra ```9111``` e ```30777``` (ovviamente questa non dovrà interferire con altre applicazioni)
 2. **Salva la porta scelta nel tuo file di configurazione** (`kovri.conf`)
-3. Configura il tuo NAT/Fifewall per consentire ad esso di accettare le connessioni TCP/UDP in entrata dalla porta (Guarda le note qui sotto se non hai accesso)
+3. Configura il tuo NAT/Fifewall per consentire ad esso di accettare le connessioni TCP/UDP in entrata dalla porta specificata (Guarda le note qui sotto se non hai accesso)
 
 Note:
 
-- **Non condividere il tuo numero di porta con nessuno altrimenti la tua anonimità sarà compromessa!**
+- **Non condividere il tuo numero di porta con nessuno altrimenti il tuo anonimato sarà compromesso!**
 - Se non salvi la porta, Kovri ne rigenererà una nuova ad ogni avvio (hai anche la scelta di indicare la porta con `--port` ad ogni avvio).
 - Se non hai accesso al tuo NAT, segui le istruzioni in [BUILDING](https://github.com/monero-project/kovri-docs/blob/master/i18n/it/building.md) per il tuo SO.
 
@@ -22,7 +22,7 @@ $ ./kovri --help
 Per le opzioni scritte in maniera dettagliata:
 
 - `kovri.conf` file di configurazione per il router e il client
-- `tunnels.conf` file di configurazione per il client/server tunnels
+- `tunnels.conf` file di configurazione per il client/server tunnel
 
 ## Step 3. Eseguire Kovri
 ```bash
@@ -32,7 +32,7 @@ $ cd build/ && ./kovri
 - Aspettare più o meno 5 minuti (il tempo di attesa può variare a seconda del tuo compuer) per entrare nella rete prima di tentare di usare servizi
 
 ## Step 4. Unisciti a noi su IRC
-1. Avvia il tuo [IRC client](https://en.wikipedia.org/wiki/List_of_IRC_clients)
+1. Avvia il tuo [client IRC](https://en.wikipedia.org/wiki/List_of_IRC_clients)
 2. Imposta il tuo client per connettersi con la porta IRC di Kovri (default 6669). Questo ti collegherà al network Irc2P (I2P's IRC network)
 3. Entra in  `#kovri` e `#kovri-dev`
 
@@ -60,7 +60,7 @@ Note:
 # Alternativamente, Docker
 
 ## Step 1. Installa Docker
-L'installazione di Docker va oltre lo scopo di questo documento, per favore leggi la [docker documentation](https://docs.docker.com/engine/installation/)
+L'installazione di Docker va oltre lo scopo di questo documento, per favore leggi la [documentazione di docker](https://docs.docker.com/engine/installation/)
 
 ## Step 2. Configurare / Aprire Firewall
 
@@ -68,7 +68,7 @@ L'immagine di Docker arriva con quella default di Kovri, ma può essere configur
 
 Dovresti scegliere una porta casuale e usare quella porta (guarda sezioni precedenti)
 
-## Step 3. Running
+## Step 3. Avviare
 
 ### Impostazioni di default
 ```bash
@@ -76,7 +76,7 @@ KOVRI_PORT=42085 && sudo docker run -p 127.0.0.1:4446:4446 -p 127.0.0.1:6669:666
 ```
 
 ### Impostazioni personalizzate
-Where `./kovri-settings/` contains `kovri.conf` and `tunnels.conf`.
+Dove `./kovri-settings/` contiene `kovri.conf` e `tunnels.conf`.
 ```bash
 KOVRI_PORT=42085 && sudo docker run -p 127.0.0.1:4446:4446 -p 127.0.0.1:6669:6669 -p $KOVRI_PORT --env KOVRI_PORT=$KOVRI_PORT -v kovri-settings:/home/kovri/.kovri/config:ro geti2p/kovri
 ```


### PR DESCRIPTION
Refreshed present Italian localization

- improved consistency
- fixe typos
- refresh of all the translated pages
- deleted repetitions
- improved fluence of the text
- fixed broken markdown in /it/building.md

This PR is split in two parts. The first part is in kovri-site (ref: monero-project/kovri-site#42)