### PR TITLE
README: remove "Alpha release coming soon"

### DIFF
--- a/i18n/da/README.md
+++ b/i18n/da/README.md
@@ -18,8 +18,6 @@ This is a translated version of the Kovri README, the original (in english) is a
 
 ### Releases
 
-Alpha release coming soon
-
 ### [Nightly Releases (bleeding edge)](https://build.getmonero.org/waterfall)
 
 | Download | Checksum | Status |

--- a/i18n/en/README_template.md
+++ b/i18n/en/README_template.md
@@ -18,8 +18,6 @@ This is a translated version of the Kovri README, the original (in english) is a
 
 ### Releases
 
-Alpha release coming soon
-
 ### [Nightly Releases (bleeding edge)](https://build.getmonero.org/waterfall)
 
 | Download | Checksum | Status |

--- a/i18n/ru/README.md
+++ b/i18n/ru/README.md
@@ -18,8 +18,6 @@ This is a translated version of the Kovri README, the original (in english) is a
 
 ### Releases
 
-Alpha release coming soon
-
 ### [Nightly Releases (bleeding edge)](https://build.getmonero.org/waterfall)
 
 | Download | Checksum | Status |


### PR DESCRIPTION
Because there will almost certainly not be any binary downloads
available that aren't bleeding-edge by the time we release.

See https://github.com/monero-project/meta/issues/252